### PR TITLE
chore: add variant to version badge component

### DIFF
--- a/docs/templates/templates-introduction.md
+++ b/docs/templates/templates-introduction.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '@site/src/components/VersionBadge';
 
-# Templates <VersionBadge version="1.2.0" />
+# Templates <VersionBadge version="1.2.0" variant="title" />
 
 :::tip Ready to get started?
 If you want to jump straight into using templates, check out:

--- a/docs/testing/change-validator.md
+++ b/docs/testing/change-validator.md
@@ -4,7 +4,7 @@ sidebar_position: 1.5
 ---
 import VersionBadge from '@site/src/components/VersionBadge';
 
-# Change validator <VersionBadge version="1.2.0" />
+# Change validator <VersionBadge version="1.2.0" variant="title" />
 
 `ChangeValidator` is a fluent assertion utility for verifying that change units carry the correct metadata — both code-based change **classes** and YAML **template-based change files**. It reads metadata via reflection or YAML parsing and asserts that the values match your expectations.
 

--- a/src/components/VersionBadge/index.jsx
+++ b/src/components/VersionBadge/index.jsx
@@ -1,15 +1,20 @@
-export default function VersionBadge({ version }) {
+const VARIANT_STYLES = {
+  default: { fontSize: '0.65em', padding: '0.1rem 0.5rem',   marginLeft: '0.5rem' },
+  title:   { fontSize: '0.5em',  padding: '0.08rem 0.4rem',  marginLeft: '0.5rem' },
+  table:   { fontSize: '0.6em',  padding: '0.05rem 0.35rem', marginLeft: '0.3rem' },
+};
+
+export default function VersionBadge({ version, variant = 'default' }) {
+  const variantStyle = VARIANT_STYLES[variant] ?? VARIANT_STYLES.default;
   return (
     <span style={{
       backgroundColor: 'var(--ifm-color-primary)',
       color: 'white',
-      padding: '0.1rem 0.5rem',
       borderRadius: '4px',
-      fontSize: '0.65em',
       fontWeight: '600',
       verticalAlign: 'middle',
-      marginLeft: '0.5rem',
       letterSpacing: '0.03em',
+      ...variantStyle,
     }}>
       Since {version}
     </span>

--- a/src/components/VersionBadge/index.jsx
+++ b/src/components/VersionBadge/index.jsx
@@ -1,6 +1,6 @@
 const VARIANT_STYLES = {
   default: { fontSize: '0.65em', padding: '0.1rem 0.5rem',   marginLeft: '0.5rem' },
-  title:   { fontSize: '0.5em',  padding: '0.08rem 0.4rem',  marginLeft: '0.5rem' },
+  title:   { fontSize: '0.35em', padding: '0.05rem 0.28rem', marginLeft: '0.5rem' },
   table:   { fontSize: '0.6em',  padding: '0.05rem 0.35rem', marginLeft: '0.3rem' },
 };
 


### PR DESCRIPTION
chore: add variant to version badge component

default 
<img width="948" height="276" alt="Screenshot 2026-03-23 at 14 06 57" src="https://github.com/user-attachments/assets/ca120b28-8bc2-4cac-9dd3-a54ff743f380" />

title
<img width="454" height="103" alt="Screenshot 2026-03-24 at 15 19 26" src="https://github.com/user-attachments/assets/82755a9d-7851-40fa-aff9-60ba984d9af9" />


table
<img width="900" height="291" alt="Screenshot 2026-03-23 at 14 07 04" src="https://github.com/user-attachments/assets/6fbe5456-0495-4782-978f-97cff8e1b60e" />
